### PR TITLE
Shrink the size of some FreeLists.

### DIFF
--- a/feature_cache.h
+++ b/feature_cache.h
@@ -24,7 +24,7 @@ class FeatureCache: public std::vector <int *> {
   void add(const std::vector<int> &);
   void shrink(std::map<int, int> *);
 
-  explicit FeatureCache(): feature_freelist_(8192 * 16) {}
+  explicit FeatureCache(): feature_freelist_(4096) {}
   virtual ~FeatureCache() {}
 
  private:

--- a/feature_index.cpp
+++ b/feature_index.cpp
@@ -98,8 +98,8 @@ void Allocator::init() {
   path_freelist_.reset(new FreeList<Path> [thread_num_]);
   node_freelist_.reset(new FreeList<Node> [thread_num_]);
   for (size_t i = 0; i < thread_num_; ++i) {
-    path_freelist_[i].set_size(8192 * 16);
-    node_freelist_[i].set_size(8192);
+    path_freelist_[i].set_size(4096);
+    node_freelist_[i].set_size(256);
   }
 }
 


### PR DESCRIPTION
These FreeLists were responsible for 5.4MiB of allocations per query.
This is an excessive amount for systems that may have hundreds or
thousands of queries in flight at any particular time.  They are now
shrunk to 82KiB per query.

The sizes were determined by some internal experimentation; they are the
smallest sizes that didn't cause reallocations on a typical NER task
(for us).  YMMV for other tasks.