### PR TITLE
Don't hardcode Java include path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+*.exp
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Java
+*.class
+*.jar

--- a/java/Makefile
+++ b/java/Makefile
@@ -3,7 +3,7 @@ JAVAC=javac
 JAVA=java
 JAR=jar
 CXX=c++
-INCLUDE=/usr/lib/jvm/java-7-openjdk-amd64/include
+INCLUDE=$(JAVA_HOME)/include
 
 PACKAGE=org/chasen/crfpp
 


### PR DESCRIPTION
Use the JAVA_HOME environment variable to get the Java include path, instead of using a hardcoded (and outdated) one.